### PR TITLE
Make base API url configurable

### DIFF
--- a/src/ui/actions/configurationActions.js
+++ b/src/ui/actions/configurationActions.js
@@ -22,12 +22,12 @@ const fetchConfigurationFailure = error => ({
     error,
 })
 
-export const fetchConfiguration = () => {
+export const fetchConfiguration = (apiUrl) => {
     return dispatch => {
         dispatch({ type: FETCH_CONFIGURATION })
 
         // http://localhost:5000/config
-        return fetch('/config')
+        return fetch(`${apiUrl}/config`)
             .then(res => {
                 if (res.status !== 200) {
                     return Promise.reject(new Error(

--- a/src/ui/app.js
+++ b/src/ui/app.js
@@ -6,7 +6,7 @@ import ThemeProvider  from './components/ThemeProvider'
 import ThemeManager   from './lib/ThemeManager'
 
 
-const MozaikWrapper = () => {
+const MozaikWrapper = (props) => {
     const store = configureStore({
         themes: {
             themes:  ThemeManager.listThemes(),
@@ -17,7 +17,7 @@ const MozaikWrapper = () => {
     return (
         <Provider store={store}>
             <ThemeProvider themes={ThemeManager.listThemes()}>
-                <Mozaik/>
+                <Mozaik {...props}/>
             </ThemeProvider>
         </Provider>
     )

--- a/src/ui/components/Mozaik.js
+++ b/src/ui/components/Mozaik.js
@@ -24,6 +24,7 @@ export default class Mozaik extends Component {
         themes:             PropTypes.object.isRequired,
         currentTheme:       PropTypes.string.isRequired,
         setTheme:           PropTypes.func.isRequired,
+        apiUrl:             PropTypes.string.isRequired,
     }
 
     static contextTypes = {
@@ -44,8 +45,8 @@ export default class Mozaik extends Component {
     }
 
     componentDidMount() {
-        const { fetchConfiguration } = this.props
-        fetchConfiguration()
+        const { fetchConfiguration, apiUrl } = this.props
+        fetchConfiguration(apiUrl)
     }
 
     render() {

--- a/src/ui/containers/MozaikContainer.js
+++ b/src/ui/containers/MozaikContainer.js
@@ -30,8 +30,8 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = dispatch => ({
-    fetchConfiguration: () => {
-        dispatch(fetchConfiguration())
+    fetchConfiguration: (apiUrl) => {
+        dispatch(fetchConfiguration(apiUrl))
     },
     play: () => {
         dispatch(play())


### PR DESCRIPTION
The `proxy` param in `package.json` changes base of all API requests but it comes from react-scripts and doesn't work after code is compiled.